### PR TITLE
Fix dependencies

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,1 +1,16 @@
-tornado
+appdirs==1.4.0
+backports-abc==0.5
+boto==2.46.1
+bz2file==0.98
+certifi==2017.1.23
+gensim==0.13.4.1
+numpy==1.12.0
+packaging==16.8
+pyparsing==2.1.10
+requests==2.13.0
+scikit-learn==0.18.1
+scipy==0.18.1
+singledispatch==3.4.0.3
+six==1.10.0
+smart-open==1.4.0
+tornado==4.4.2


### PR DESCRIPTION
Scikit-learn, Gensim, and Tornado were improperly listed on the requirements file.